### PR TITLE
fix: allow nested <section> elements in special sections

### DIFF
--- a/lib/config/schema.mjs
+++ b/lib/config/schema.mjs
@@ -16,6 +16,7 @@ export const XML_SCHEMA = {
       'figure',
       'iref',
       'ol',
+      'section',
       'sourcecode',
       't',
       'table',

--- a/lib/modules/sections.mjs
+++ b/lib/modules/sections.mjs
@@ -769,7 +769,7 @@ export async function validateIANAConsiderationsSection (doc, { mode = MODES.NOR
         } else {
           for (const key of childrenTypes) {
             if (!XML_SCHEMA.section.allowedChildren.includes(key)) {
-              result.push(new ValidationError('INVALID_IANA_CONSIDERATIONS_SECTION_CHILD', `The security considerations section must consist of ${XML_SCHEMA.section.allowedChildren.map(e => '<' + e + '>').join(', ')} elements only.`, {
+              result.push(new ValidationError('INVALID_IANA_CONSIDERATIONS_SECTION_CHILD', `The IANA considerations section must consist of ${XML_SCHEMA.section.allowedChildren.map(e => '<' + e + '>').join(', ')} elements only.`, {
                 path: `rfc.middle.section[${secSectionIdx}].${key}`,
                 ref: 'https://www.rfc-editor.org/rfc/rfc7991.html#section-2.46'
               }))

--- a/tests/sections.test.js
+++ b/tests/sections.test.js
@@ -405,6 +405,13 @@ describe('document should have a valid introduction section', () => {
       set(doc, 'data.rfc.middle.section[0].abc', 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.')
       await expect(validateIntroductionSection(doc)).resolves.toContainError('INVALID_INTRODUCTION_SECTION_CHILD', ValidationError)
     })
+    test('valid introduction section with nested section', async () => {
+      const doc = cloneDeep(baseXMLDoc)
+      set(doc, 'data.rfc.middle.section[0].name', 'Introduction')
+      set(doc, 'data.rfc.middle.section[0].t', 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.')
+      set(doc, 'data.rfc.middle.section[0].section', [{ name: 'Background', t: 'Some background.' }])
+      await expect(validateIntroductionSection(doc)).resolves.toHaveLength(0)
+    })
   })
 })
 
@@ -505,6 +512,13 @@ describe('document should have a valid security considerations section', () => {
       set(doc, 'data.rfc.middle.section[0].t', 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.')
       set(doc, 'data.rfc.middle.section[0].abc', 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.')
       await expect(validateSecurityConsiderationsSection(doc)).resolves.toContainError('INVALID_SECURITY_CONSIDERATIONS_SECTION_CHILD', ValidationError)
+    })
+    test('valid security considerations section with nested section', async () => {
+      const doc = cloneDeep(baseXMLDoc)
+      set(doc, 'data.rfc.middle.section[0].name', 'Security Considerations')
+      set(doc, 'data.rfc.middle.section[0].t', 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.')
+      set(doc, 'data.rfc.middle.section[0].section', [{ name: 'Threat Model', t: 'Some threats.' }])
+      await expect(validateSecurityConsiderationsSection(doc)).resolves.toHaveLength(0)
     })
   })
 })
@@ -944,6 +958,13 @@ describe('document should have a valid IANA considerations section', () => {
       set(doc, 'data.rfc.middle.section[0].t', 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.')
       set(doc, 'data.rfc.middle.section[0].abc', 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.')
       await expect(validateIANAConsiderationsSection(doc)).resolves.toContainError('INVALID_IANA_CONSIDERATIONS_SECTION_CHILD', ValidationError)
+    })
+    test('valid IANA considerations section with nested section', async () => {
+      const doc = cloneDeep(baseXMLDoc)
+      set(doc, 'data.rfc.middle.section[0].name', 'IANA Considerations')
+      set(doc, 'data.rfc.middle.section[0].t', 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.')
+      set(doc, 'data.rfc.middle.section[0].section', [{ name: 'New Registries', t: 'Some registries.' }])
+      await expect(validateIANAConsiderationsSection(doc)).resolves.toHaveLength(0)
     })
   })
   describe('TXT Document Type', () => {


### PR DESCRIPTION
## Summary
- Adds `section` to `XML_SCHEMA.section.allowedChildren` so nested `<section>` elements are permitted per RFC 7991 §2.46
- Fixes IANA considerations error message that incorrectly said "security considerations"
- Adds test cases confirming nested sections are valid for all three section types

Fixes #248, Fixes #249, Fixes #251

## Test plan
- [x] All 79 existing section tests pass
- [x] 3 new tests verify `<section>` children are accepted in Introduction, Security Considerations, and IANA Considerations sections