### PR TITLE
test: Use current year in console date validation tests

### DIFF
--- a/tests/txt.test.js
+++ b/tests/txt.test.js
@@ -330,9 +330,9 @@ describe('The copyright date is not valid.', () => {
     const currentYear = new Date().getFullYear()
     doc.data.extractedElements.copyrightDates = [currentYear]
 
-    await expect(validateCopyrightDate(doc, { mode: MODES.NORMAL, year: 2025 })).resolves.toHaveLength(0)
-    await expect(validateCopyrightDate(doc, { mode: MODES.FORGIVE_CHECKLIST, year: 2025 })).resolves.toHaveLength(0)
-    await expect(validateCopyrightDate(doc, { mode: MODES.SUBMISSION, year: 2025 })).resolves.toHaveLength(0)
+    await expect(validateCopyrightDate(doc, { mode: MODES.NORMAL, year: currentYear })).resolves.toHaveLength(0)
+    await expect(validateCopyrightDate(doc, { mode: MODES.FORGIVE_CHECKLIST, year: currentYear })).resolves.toHaveLength(0)
+    await expect(validateCopyrightDate(doc, { mode: MODES.SUBMISSION, year: currentYear })).resolves.toHaveLength(0)
   })
   test('Copyright text date not valid', async () => {
     const doc = cloneDeep(baseTXTDoc)


### PR DESCRIPTION
Fixes #258 