### PR TITLE
fix: downgrade FILENAME_MISSING_COMPONENTS to warning (#32)

### DIFF
--- a/lib/modules/filename.mjs
+++ b/lib/modules/filename.mjs
@@ -58,7 +58,7 @@ export async function validateFilename (filename, { mode = MODES.NORMAL } = {}) 
 
   // Ensure filename has at least 4 components
   if (filenameParts[0].split('-').length < 4) {
-    result.push(new ValidationError('FILENAME_MISSING_COMPONENTS', 'Filename must consists of at least 4 components (e.g. draft-author-subject-version).', { ref: errRefUrl }))
+    result.push(new ValidationWarning('FILENAME_MISSING_COMPONENTS', 'Filename should consist of at least 4 components (e.g. draft-author-subject-version).', { ref: errRefUrl }))
   }
 
   return result

--- a/tests/filename.test.js
+++ b/tests/filename.test.js
@@ -111,7 +111,7 @@ describe('filename must have at least 4 components', () => {
   test('valid 5 components', async () => {
     await expect(validateFilename('draft-ietf-abcd-efgh-01.txt')).resolves.toHaveLength(0)
   })
-  test('invalid 3 components', async () => {
-    await expect(validateFilename('draft-ietf-01.txt')).resolves.toContainError('FILENAME_MISSING_COMPONENTS')
+  test('3 components triggers warning', async () => {
+    await expect(validateFilename('draft-ietf-01.txt')).resolves.toContainError('FILENAME_MISSING_COMPONENTS', ValidationWarning)
   })
 })


### PR DESCRIPTION
## Summary
Fixes #32

The 4-component requirement is advice, not a strict rule. Some valid draft names like `draft-rswg-rfc7997bis` have only 3 components but are compliant with the naming specification.

## Changes
- Downgrade FILENAME_MISSING_COMPONENTS from error to warning
- Update message from "must consist" to "should consist"

## Test Plan
- ✅ All 25 filename tests pass with 100% coverage
- ✅ Test updated to expect ValidationWarning

## Examples
Valid 3-component names: `draft-rswg-rfc7997bis-02`, `draft-iab-example-00`