### PR TITLE
fix: improve downref warning messages (#221)

### DIFF
--- a/lib/modules/downref.mjs
+++ b/lib/modules/downref.mjs
@@ -45,29 +45,30 @@ export async function validateDownrefs (doc, { mode = MODES.NORMAL } = {}) {
 
         if (refStatus !== null && refStatus < statusCategory) {
           const isDownref = await checkReferencesInDownrefs([ref])
+          const docType = doc.docKind === 'rfc' ? 'this RFC' : "this draft's intended status"
           if (isDownref.length > 0) {
             switch (mode) {
               case MODES.NORMAL:
-                result.push(new ValidationWarning('DOWNREF_TO_LOWER_STATUS_IN_REGISTRY', `Reference to ${ref}, which has a lower status and is listed in the Downref Registry.`, {
-                  ref: `https://datatracker.ietf.org/doc/${ref}`
+                result.push(new ValidationWarning('DOWNREF_TO_LOWER_STATUS_IN_REGISTRY', `Reference to ${ref}, which has a lower status than ${docType} and is listed in the Downref Registry.`, {
+                  ref: 'https://www.rfc-editor.org/info/bcp97'
                 }))
                 break
               case MODES.FORGIVE_CHECKLIST:
-                result.push(new ValidationWarning('DOWNREF_TO_LOWER_STATUS_IN_REGISTRY', `Reference to ${ref}, which has a lower status and is listed in the Downref Registry.`, {
-                  ref: `https://datatracker.ietf.org/doc/${ref}`
+                result.push(new ValidationWarning('DOWNREF_TO_LOWER_STATUS_IN_REGISTRY', `Reference to ${ref}, which has a lower status than ${docType} and is listed in the Downref Registry.`, {
+                  ref: 'https://www.rfc-editor.org/info/bcp97'
                 }))
                 break
             }
           } else {
             switch (mode) {
               case MODES.NORMAL:
-                result.push(new ValidationError('DOWNREF_TO_LOWER_STATUS', `Reference to ${ref}, which has a lower status than the current document.`, {
-                  ref: `https://datatracker.ietf.org/doc/${ref}`
+                result.push(new ValidationError('DOWNREF_TO_LOWER_STATUS', `Reference to ${ref}, which has a lower status than ${docType}. This reference is not in the Downref Registry.`, {
+                  ref: 'https://www.rfc-editor.org/info/bcp97'
                 }))
                 break
               case MODES.FORGIVE_CHECKLIST:
-                result.push(new ValidationWarning('DOWNREF_TO_LOWER_STATUS', `Reference to ${ref}, which has a lower status than the current document.`, {
-                  ref: `https://datatracker.ietf.org/doc/${ref}`
+                result.push(new ValidationWarning('DOWNREF_TO_LOWER_STATUS', `Reference to ${ref}, which has a lower status than ${docType}. This reference is not in the Downref Registry.`, {
+                  ref: 'https://www.rfc-editor.org/info/bcp97'
                 }))
                 break
             }
@@ -111,13 +112,14 @@ export async function validateDownrefs (doc, { mode = MODES.NORMAL } = {}) {
 
         if (refStatus !== null && refStatus < docStatus) {
           const isDownref = await checkReferencesInDownrefs([ref])
+          const docType = doc.docKind === 'rfc' ? 'this RFC' : "this draft's intended status"
           if (isDownref.length > 0) {
             switch (mode) {
               case MODES.NORMAL:
                 result.push(
                   new ValidationWarning(
                     'DOWNREF_TO_LOWER_STATUS_IN_REGISTRY',
-                    `Reference to ${ref}, which has a lower status and is listed in the Downref Registry.`,
+                    `Reference to ${ref}, which has a lower status than ${docType} and is listed in the Downref Registry.`,
                     { ref: 'https://www.rfc-editor.org/info/bcp97' }
                   )
                 )
@@ -126,7 +128,7 @@ export async function validateDownrefs (doc, { mode = MODES.NORMAL } = {}) {
                 result.push(
                   new ValidationWarning(
                     'DOWNREF_TO_LOWER_STATUS_IN_REGISTRY',
-                    `Reference to ${ref}, which has a lower status and is listed in the Downref Registry.`,
+                    `Reference to ${ref}, which has a lower status than ${docType} and is listed in the Downref Registry.`,
                     { ref: 'https://www.rfc-editor.org/info/bcp97' }
                   )
                 )
@@ -137,8 +139,8 @@ export async function validateDownrefs (doc, { mode = MODES.NORMAL } = {}) {
               case MODES.NORMAL:
                 result.push(
                   new ValidationError(
-                    'POSSIBLE_DOWNREF',
-                    `Reference to ${ref} is possible downref`,
+                    'DOWNREF_TO_LOWER_STATUS',
+                    `Reference to ${ref}, which has a lower status than ${docType}. This reference is not in the Downref Registry.`,
                     { ref: 'https://www.rfc-editor.org/info/bcp97' }
                   )
                 )
@@ -146,8 +148,8 @@ export async function validateDownrefs (doc, { mode = MODES.NORMAL } = {}) {
               case MODES.FORGIVE_CHECKLIST:
                 result.push(
                   new ValidationWarning(
-                    'POSSIBLE_DOWNREF',
-                    `Reference to ${ref} is possible downref`,
+                    'DOWNREF_TO_LOWER_STATUS',
+                    `Reference to ${ref}, which has a lower status than ${docType}. This reference is not in the Downref Registry.`,
                     { ref: 'https://www.rfc-editor.org/info/bcp97' }
                   )
                 )


### PR DESCRIPTION
## Summary
Fixes #221

Improve DOWNREF_TO_LOWER_STATUS messages to be more informative and context-aware.

## Changes
- Make message context-sensitive (draft vs RFC)
- Explicitly state whether reference is in Downref Registry
- Point ref URL to BCP97 (explains downrefs) instead of target RFC

## Examples

**Before:**
```
Reference to RFC 7967, which has a lower status than the current document.
Ref: https://datatracker.ietf.org/doc/RFC 7967
```

**After (draft):**
```
Reference to RFC 7967, which has a lower status than this draft's intended status. 
This reference is not in the Downref Registry.
Ref: https://www.rfc-editor.org/info/bcp97
```

**After (RFC):**
```
Reference to RFC 7967, which has a lower status than this RFC and is listed in 
the Downref Registry.
Ref: https://www.rfc-editor.org/info/bcp97
```