### PR TITLE
fix: improve OBSOLETE_*_REFERENCE error messages (#190)

### DIFF
--- a/lib/modules/downref.mjs
+++ b/lib/modules/downref.mjs
@@ -367,23 +367,23 @@ export async function validateNormativeReferences (doc, { mode = MODES.NORMAL } 
         }
 
         if (rfcInfo.obsoleted_by?.length > 0) {
-          const obsoletedByList = rfcInfo.obsoleted_by.join(', ')
-          const message = `The referenced document RFC ${rfcNum} is obsolete and has been replaced by: ${obsoletedByList}.`
+          const obsoletedByList = rfcInfo.obsoleted_by.map(rfc => `RFC${rfc}`).join(', ')
+          const message = `RFC ${rfcNum} is obsolete and has been replaced by: ${obsoletedByList}.`
 
           if (mode === MODES.NORMAL) {
             result.push(new ValidationError(
-              'OBSOLETE_DOCUMENT',
+              'OBSOLETE_REFERENCE',
               message,
               {
-                ref: `https://www.rfc-editor.org/info/rfc${rfcNum}`
+                ref: 'https://authors.ietf.org/en/required-content#references'
               }
             ))
           } else if (mode === MODES.FORGIVE_CHECKLIST) {
             result.push(new ValidationWarning(
-              'OBSOLETE_DOCUMENT',
+              'OBSOLETE_REFERENCE',
               message,
               {
-                ref: `https://www.rfc-editor.org/info/rfc${rfcNum}`
+                ref: 'https://authors.ietf.org/en/required-content#references'
               }
             ))
           }
@@ -416,23 +416,23 @@ export async function validateNormativeReferences (doc, { mode = MODES.NORMAL } 
         }
 
         if (rfcInfo.obsoleted_by.length > 0) {
-          const obsoletedByList = rfcInfo.obsoleted_by.join(', ')
-          const message = `The referenced document RFC ${rfcNum} is obsolete and has been replaced by: ${obsoletedByList}.`
+          const obsoletedByList = rfcInfo.obsoleted_by.map(rfc => `RFC${rfc}`).join(', ')
+          const message = `RFC ${rfcNum} is obsolete and has been replaced by: ${obsoletedByList}.`
 
           if (mode === MODES.NORMAL) {
             result.push(new ValidationError(
-              'OBSOLETE_DOCUMENT',
+              'OBSOLETE_REFERENCE',
               message,
               {
-                ref: `https://www.rfc-editor.org/info/rfc${rfcNum}`
+                ref: 'https://authors.ietf.org/en/required-content#references'
               }
             ))
           } else if (mode === MODES.FORGIVE_CHECKLIST) {
             result.push(new ValidationWarning(
-              'OBSOLETE_DOCUMENT',
+              'OBSOLETE_REFERENCE',
               message,
               {
-                ref: `https://www.rfc-editor.org/info/rfc${rfcNum}`
+                ref: 'https://authors.ietf.org/en/required-content#references'
               }
             ))
           }
@@ -495,20 +495,20 @@ export async function validateUnclassifiedReferences (doc, { mode = MODES.NORMAL
         }
 
         if (rfcInfo.obsoleted_by.length > 0) {
-          const obsoletedByList = rfcInfo.obsoleted_by.join(', ')
-          const message = `The unclassified reference ${ref} is obsolete and has been replaced by: ${obsoletedByList}.`
+          const obsoletedByList = rfcInfo.obsoleted_by.map(rfc => `RFC${rfc}`).join(', ')
+          const message = `RFC ${ref} is obsolete and has been replaced by: ${obsoletedByList}.`
 
           if (mode === MODES.NORMAL) {
             result.push(new ValidationError(
-              'OBSOLETE_UNCLASSIFIED_REFERENCE',
+              'OBSOLETE_REFERENCE',
               message,
-              { ref: `https://www.rfc-editor.org/info/rfc${rfcInfo.rfc}` }
+              { ref: 'https://authors.ietf.org/en/required-content#references' }
             ))
           } else if (mode === MODES.FORGIVE_CHECKLIST) {
             result.push(new ValidationWarning(
-              'OBSOLETE_UNCLASSIFIED_REFERENCE',
+              'OBSOLETE_REFERENCE',
               message,
-              { ref: `https://www.rfc-editor.org/info/rfc${rfcInfo.rfc}` }
+              { ref: 'https://authors.ietf.org/en/required-content#references' }
             ))
           }
         }
@@ -541,13 +541,13 @@ export async function validateUnclassifiedReferences (doc, { mode = MODES.NORMAL
         }
 
         if (rfcInfo.obsoleted_by.length) {
-          const obsoletedByList = rfcInfo.obsoleted_by.join(', ')
-          const message = `The unclassified reference RFC ${rfcNum} is obsolete and has been replaced by: ${obsoletedByList}`
+          const obsoletedByList = rfcInfo.obsoleted_by.map(rfc => `RFC${rfc}`).join(', ')
+          const message = `RFC ${rfcNum} is obsolete and has been replaced by: ${obsoletedByList}.`
 
           result.push(
             mode === MODES.NORMAL
-              ? new ValidationError('OBSOLETE_UNCLASSIFIED_REFERENCE', message, { ref: `https://www.rfc-editor.org/info/rfc${rfcInfo.rfc}` })
-              : new ValidationWarning('OBSOLETE_UNCLASSIFIED_REFERENCE', message, { ref: `https://www.rfc-editor.org/info/rfc${rfcInfo.rfc}` })
+              ? new ValidationError('OBSOLETE_REFERENCE', message, { ref: 'https://authors.ietf.org/en/required-content#references' })
+              : new ValidationWarning('OBSOLETE_REFERENCE', message, { ref: 'https://authors.ietf.org/en/required-content#references' })
           )
         }
       }
@@ -596,20 +596,20 @@ export async function validateInformativeReferences (doc, { mode = MODES.NORMAL 
     }
 
     if (rfcInfo.obsoleted_by.length > 0) {
-      const obsoletedByList = rfcInfo.obsoleted_by.join(', ')
-      const message = `The informative reference RFC ${ref} is obsolete and has been replaced by: ${obsoletedByList}.`
+      const obsoletedByList = rfcInfo.obsoleted_by.map(rfc => `RFC${rfc}`).join(', ')
+      const message = `RFC ${ref} is obsolete and has been replaced by: ${obsoletedByList}.`
 
       if (mode === MODES.NORMAL) {
         result.push(new ValidationError(
-          'OBSOLETE_INFORMATIVE_REFERENCE',
+          'OBSOLETE_REFERENCE',
           message,
-          { ref: `https://www.rfc-editor.org/info/rfc${rfcInfo.rfc}` }
+          { ref: 'https://authors.ietf.org/en/required-content#references' }
         ))
       } else if (mode === MODES.FORGIVE_CHECKLIST) {
         result.push(new ValidationWarning(
-          'OBSOLETE_INFORMATIVE_REFERENCE',
+          'OBSOLETE_REFERENCE',
           message,
-          { ref: `https://www.rfc-editor.org/info/rfc${rfcInfo.rfc}` }
+          { ref: 'https://authors.ietf.org/en/required-content#references' }
         ))
       }
     }

--- a/tests/downref.test.js
+++ b/tests/downref.test.js
@@ -386,8 +386,8 @@ describe('validateNormativeReferences', () => {
       const result = await validateNormativeReferences(doc, { mode: MODES.NORMAL })
       expect(result).toContainEqual(
         expect.objectContaining({
-          name: 'OBSOLETE_DOCUMENT',
-          message: expect.stringContaining('RFC 4087 is obsolete and has been replaced by: 9000.')
+          name: 'OBSOLETE_REFERENCE',
+          message: expect.stringContaining('RFC 4087 is obsolete and has been replaced by: RFC9000.')
         })
       )
     })
@@ -401,8 +401,8 @@ describe('validateNormativeReferences', () => {
       const result = await validateNormativeReferences(doc, { mode: MODES.FORGIVE_CHECKLIST })
       expect(result).toContainEqual(
         expect.objectContaining({
-          name: 'OBSOLETE_DOCUMENT',
-          message: expect.stringContaining('RFC 4087 is obsolete and has been replaced by: 9000.')
+          name: 'OBSOLETE_REFERENCE',
+          message: expect.stringContaining('RFC 4087 is obsolete and has been replaced by: RFC9000.')
         })
       )
     })
@@ -465,7 +465,7 @@ describe('validateUnclassifiedReferences', () => {
       ])
 
       const result = await validateUnclassifiedReferences(doc, { mode: MODES.NORMAL })
-      expect(result).toContainError('OBSOLETE_UNCLASSIFIED_REFERENCE', ValidationError)
+      expect(result).toContainError('OBSOLETE_REFERENCE', ValidationError)
     })
 
     test('FORGIVE_CHECKLIST mode for an obsolete unclassified RFC', async () => {
@@ -475,7 +475,7 @@ describe('validateUnclassifiedReferences', () => {
       ])
 
       const result = await validateUnclassifiedReferences(doc, { mode: MODES.FORGIVE_CHECKLIST })
-      expect(result).toContainError('OBSOLETE_UNCLASSIFIED_REFERENCE', ValidationWarning)
+      expect(result).toContainError('OBSOLETE_REFERENCE', ValidationWarning)
     })
   })
 
@@ -487,7 +487,7 @@ describe('validateUnclassifiedReferences', () => {
       ])
 
       const result = await validateUnclassifiedReferences(doc, { mode: MODES.NORMAL })
-      expect(result).toContainError('OBSOLETE_UNCLASSIFIED_REFERENCE', ValidationError)
+      expect(result).toContainError('OBSOLETE_REFERENCE', ValidationError)
     })
 
     test('FORGIVE_CHECKLIST mode for an obsolete unclassified RFC', async () => {
@@ -497,7 +497,7 @@ describe('validateUnclassifiedReferences', () => {
       ])
 
       const result = await validateUnclassifiedReferences(doc, { mode: MODES.FORGIVE_CHECKLIST })
-      expect(result).toContainError('OBSOLETE_UNCLASSIFIED_REFERENCE', ValidationWarning)
+      expect(result).toContainError('OBSOLETE_REFERENCE', ValidationWarning)
     })
 
     test('unclassified reference with undefined status', async () => {
@@ -717,8 +717,8 @@ describe('validateInformativeReferences', () => {
     const result = await validateInformativeReferences(doc, { mode: MODES.NORMAL })
     expect(result).toContainEqual(
       expect.objectContaining({
-        name: 'OBSOLETE_INFORMATIVE_REFERENCE',
-        message: expect.stringContaining('The informative reference RFC 5087 is obsolete and has been replaced by: 9000.')
+        name: 'OBSOLETE_REFERENCE',
+        message: expect.stringContaining('RFC 5087 is obsolete and has been replaced by: RFC9000.')
       })
     )
   })
@@ -732,8 +732,8 @@ describe('validateInformativeReferences', () => {
     const result = await validateInformativeReferences(doc, { mode: MODES.FORGIVE_CHECKLIST })
     expect(result).toContainEqual(
       expect.objectContaining({
-        name: 'OBSOLETE_INFORMATIVE_REFERENCE',
-        message: expect.stringContaining('The informative reference RFC 5087 is obsolete and has been replaced by: 9000.')
+        name: 'OBSOLETE_REFERENCE',
+        message: expect.stringContaining('RFC 5087 is obsolete and has been replaced by: RFC9000.')
       })
     )
   })


### PR DESCRIPTION
## Summary
Fixes #190

Consolidate and improve obsolete reference errors to be clearer and more helpful.

## Changes
- Collapse OBSOLETE_NORMATIVE_REFERENCE, OBSOLETE_INFORMATIVE_REFERENCE, and OBSOLETE_UNCLASSIFIED_REFERENCE into single **OBSOLETE_REFERENCE** code
- Simplify messages (remove redundant prefixes)
- Format replacement RFCs properly (RFC9110 instead of 9110)
- Point ref URL to authors.ietf.org instead of rfc-editor.org/info/rfcUNDEFINED

## Examples

**Before:**
```
The unclassified reference 7231 is obsolete and has been replaced by: 9110
Ref: https://www.rfc-editor.org/info/rfcundefined
```

**After:**
```
RFC 7231 is obsolete and has been replaced by: RFC9110.
Ref: https://authors.ietf.org/en/required-content#references
```

## Breaking Changes
- Error code changed from OBSOLETE_{NORMATIVE,INFORMATIVE,UNCLASSIFIED}_REFERENCE to OBSOLETE_REFERENCE
- Ref URL changed to point to authors.ietf.org