### PR TITLE
fix: improve references section validation (#227, #218)

### DIFF
--- a/lib/modules/sections.mjs
+++ b/lib/modules/sections.mjs
@@ -548,8 +548,8 @@ export async function validateReferencesSection (doc, { mode = MODES.NORMAL } = 
           case MODES.NORMAL: {
             result.push(
               new ValidationError(
-                'MISSING_REFERENCES_SUBSECTIONS',
-                'The references section does not contain any valid subsections.',
+                'MISSING_REFERENCES_CLASSIFICATION',
+                'References must be classified as Normative or Informative. Use subsections (e.g., "Normative References" and "Informative References") or rename the section to indicate its type.',
                 {
                   ref: 'https://authors.ietf.org/required-content#references'
                 }
@@ -560,8 +560,8 @@ export async function validateReferencesSection (doc, { mode = MODES.NORMAL } = 
           case MODES.FORGIVE_CHECKLIST: {
             result.push(
               new ValidationWarning(
-                'MISSING_REFERENCES_SUBSECTIONS',
-                'The references section does not contain any valid subsections.',
+                'MISSING_REFERENCES_CLASSIFICATION',
+                'References must be classified as Normative or Informative. Use subsections (e.g., "Normative References" and "Informative References") or rename the section to indicate its type.',
                 {
                   ref: 'https://authors.ietf.org/required-content#references'
                 }
@@ -623,6 +623,16 @@ export async function validateReferencesSection (doc, { mode = MODES.NORMAL } = 
       // -> Check if there's only 1 references section, which won't be an array
       if (isPlainObject(refsSections)) {
         refsSections = [refsSections]
+      }
+      // -> Handle nested wrapper pattern: a single outer <references> with
+      //    <name>References</name> containing inner <references> subsections.
+      //    This is the standard structure used by almost every RFC.
+      if (refsSections.length === 1 && refsSections[0].references) {
+        let innerRefs = refsSections[0].references
+        if (isPlainObject(innerRefs)) {
+          innerRefs = [innerRefs]
+        }
+        refsSections = innerRefs
       }
       if (refsSections?.length > 0) {
         let idx = 0

--- a/tests/sections.test.js
+++ b/tests/sections.test.js
@@ -856,8 +856,12 @@ describe('document should have valid references sections', () => {
         `
       }
       await expect(validateReferencesSection(doc, { mode: MODES.NORMAL })).resolves.toContainError(
-        'MISSING_REFERENCES_SUBSECTIONS',
+        'MISSING_REFERENCES_CLASSIFICATION',
         ValidationError
+      )
+      await expect(validateReferencesSection(doc, { mode: MODES.FORGIVE_CHECKLIST })).resolves.toContainError(
+        'MISSING_REFERENCES_CLASSIFICATION',
+        ValidationWarning
       )
     })
 
@@ -922,6 +926,36 @@ describe('document should have valid references sections', () => {
       await expect(validateReferencesSection(doc)).resolves.toContainError('INVALID_REFERENCES_NAME', ValidationError)
       await expect(validateReferencesSection(doc, { mode: MODES.FORGIVE_CHECKLIST })).resolves.toContainError('INVALID_REFERENCES_NAME', ValidationWarning)
       await expect(validateReferencesSection(doc, { mode: MODES.SUBMISSION })).resolves.toHaveLength(0)
+    })
+    test('valid nested references wrapper with inner normative and informative sections', async () => {
+      const doc = cloneDeep(baseXMLDoc)
+      set(doc, 'data.rfc.back.references', {
+        name: 'References',
+        references: [
+          { name: 'Normative References' },
+          { name: 'Informative References' }
+        ]
+      })
+      await expect(validateReferencesSection(doc)).resolves.toHaveLength(0)
+    })
+    test('nested references wrapper with invalid inner section names should error', async () => {
+      const doc = cloneDeep(baseXMLDoc)
+      set(doc, 'data.rfc.back.references', {
+        name: 'References',
+        references: [
+          { name: 'Normative References' },
+          { name: 'Other Stuff' }
+        ]
+      })
+      await expect(validateReferencesSection(doc)).resolves.toContainError('INVALID_REFERENCES_NAME', ValidationError)
+    })
+    test('nested references wrapper with single inner section', async () => {
+      const doc = cloneDeep(baseXMLDoc)
+      set(doc, 'data.rfc.back.references', {
+        name: 'References',
+        references: { name: 'Normative References' }
+      })
+      await expect(validateReferencesSection(doc)).resolves.toHaveLength(0)
     })
   })
 })


### PR DESCRIPTION
## Summary

The standard nested `<references>` wrapper pattern (`<references><name>References</name>` containing inner Normative/Informative `<references>` subsections) was incorrectly triggering `INVALID_REFERENCES_NAME` on the outer wrapper.

## Fix
 - The validator now detects the wrapper and validates the inner sections instead.
 - Renamed `MISSING_REFERENCES_SUBSECTIONS` to `MISSING_REFERENCES_CLASSIFICATION`. The previous message implied subsections were always required, which is not the case (e.g., a standalone `8. Normative References` is valid).
 
 ## Checklist

- [x] Added unit tests for nested XML wrapper (valid wrapper, invalid inner names, single inner section)
- [x] Updated existing text test to expect new `MISSING_REFERENCES_CLASSIFICATION` error code
- [x] All 443 tests pass (`npm test`)
- [x] Ran `node cli.js` against an XML file that uses the standard nested references wrapper pattern and previously triggered the `INVALID_REFERENCES_NAME` error — confirmed the false positive is resolved and the references section validates cleanly

## Issues Resolved

- Fixes #227
- Fixes #218