### PR TITLE
fix: extract xi:include references as external entities (#253)

### DIFF
--- a/lib/parsers/xml.mjs
+++ b/lib/parsers/xml.mjs
@@ -54,11 +54,11 @@ export async function parse (rawText, filename) {
     return ''
   })
 
-  // extract xi:include references (e.g. bibxml includes for RFC/BCP references)
+  // extract xi:include references from bib.ietf.org bibxml URLs only
   let xiMatch
   while ((xiMatch = xiIncludeRgx.exec(rawText)) !== null) {
     const href = xiMatch[1]
-    const refMatch = href.match(/reference\.([A-Z]+)\.?0*(\d+)\.xml$/)
+    const refMatch = href.match(/^https?:\/\/bib\.ietf\.org\/.*\/reference\.([A-Z]+)\.?0*(\d+)\.xml$/)
     if (refMatch) {
       externalEntities.push({
         original: xiMatch[0],

--- a/lib/parsers/xml.mjs
+++ b/lib/parsers/xml.mjs
@@ -5,6 +5,7 @@ import { get, toSafeInteger } from 'lodash-es'
 
 const linePIRgx = /<\?line [0-9]+\?>/gi
 const externalEntityRgx = /<!ENTITY\s+([a-zA-Z0-9-._]+)\s+(SYSTEM|PUBLIC)\s+"(.*)">/g
+const xiIncludeRgx = /<xi:include\s+href="([^"]*)"[^>]*\/?>/g
 
 /**
  * @typedef {Object} XMLDocObject
@@ -52,6 +53,21 @@ export async function parse (rawText, filename) {
     })
     return ''
   })
+
+  // extract xi:include references (e.g. bibxml includes for RFC/BCP references)
+  let xiMatch
+  while ((xiMatch = xiIncludeRgx.exec(rawText)) !== null) {
+    const href = xiMatch[1]
+    const refMatch = href.match(/reference\.([A-Z]+)\.?0*(\d+)\.xml$/)
+    if (refMatch) {
+      externalEntities.push({
+        original: xiMatch[0],
+        name: refMatch[1] + refMatch[2],
+        type: 'xi:include',
+        url: href
+      })
+    }
+  }
 
   // parse XML document
   let data

--- a/tests/keywords.test.js
+++ b/tests/keywords.test.js
@@ -5,6 +5,7 @@ import {
   validate2119Keywords,
   validateTermsStyle
 } from '../lib/modules/keywords.mjs'
+import { parse as parseXml } from '../lib/parsers/xml.mjs'
 import { baseTXTDoc, baseXMLDoc } from './fixtures/base-doc.mjs'
 import { cloneDeep, set } from 'lodash-es'
 
@@ -829,6 +830,51 @@ describe('document should have valid RFC2119 keywords', () => {
       ])
       await expect(validate2119Keywords(doc)).resolves.toHaveLength(0)
     })
+  })
+})
+
+describe('xi:include extraction should only accept bib.ietf.org URLs', () => {
+  const makeXml = (href) => `<?xml version='1.0' encoding='utf-8'?>
+<rfc version="3">
+  <front>
+    <title>Test</title>
+    <seriesInfo name="Internet-Draft" value="draft-test-00" />
+    <author fullname="Test Author"><organization>Test</organization></author>
+    <date year="2026" month="1" day="1" />
+    <abstract><t>Test.</t></abstract>
+  </front>
+  <middle><section><name>Introduction</name><t>Test.</t></section></middle>
+  <back>
+    <references>
+      <name>Normative References</name>
+      <xi:include href="${href}" />
+    </references>
+  </back>
+</rfc>`
+
+  test('accepts bib.ietf.org bibxml URL', async () => {
+    const { doc } = await parseXml(makeXml('https://bib.ietf.org/public/rfc/bibxml/reference.RFC.2119.xml'), 'draft-test-00.xml')
+    expect(doc.externalEntities).toContainEqual(expect.objectContaining({ name: 'RFC2119', type: 'xi:include' }))
+  })
+  test('accepts bib.ietf.org BCP URL and strips leading zeros', async () => {
+    const { doc } = await parseXml(makeXml('https://bib.ietf.org/public/rfc/bibxml/reference.BCP.0014.xml'), 'draft-test-00.xml')
+    expect(doc.externalEntities).toContainEqual(expect.objectContaining({ name: 'BCP14', type: 'xi:include' }))
+  })
+  test('rejects non-bib.ietf.org host', async () => {
+    const { doc } = await parseXml(makeXml('https://evil.com/public/rfc/bibxml/reference.RFC.2119.xml'), 'draft-test-00.xml')
+    expect(doc.externalEntities).toHaveLength(0)
+  })
+  test('rejects subdomain spoofing of bib.ietf.org', async () => {
+    const { doc } = await parseXml(makeXml('https://bib.ietf.org.evil.com/public/rfc/bibxml/reference.RFC.2119.xml'), 'draft-test-00.xml')
+    expect(doc.externalEntities).toHaveLength(0)
+  })
+  test('rejects file:// scheme', async () => {
+    const { doc } = await parseXml(makeXml('file:///etc/passwd'), 'draft-test-00.xml')
+    expect(doc.externalEntities).toHaveLength(0)
+  })
+  test('rejects ftp:// scheme', async () => {
+    const { doc } = await parseXml(makeXml('ftp://bib.ietf.org/public/rfc/bibxml/reference.RFC.2119.xml'), 'draft-test-00.xml')
+    expect(doc.externalEntities).toHaveLength(0)
   })
 })
 

--- a/tests/keywords.test.js
+++ b/tests/keywords.test.js
@@ -820,6 +820,15 @@ describe('document should have valid RFC2119 keywords', () => {
       ])
       await expect(validate2119Keywords(doc)).resolves.toHaveLength(0)
     })
+    test('valid keywords with xi:include-sourced BCP14 reference', async () => {
+      const doc = cloneDeep(baseXMLDoc)
+      doc.externalEntities = [{ name: 'BCP14', type: 'xi:include', url: 'https://bib.ietf.org/public/rfc/bibxml/reference.BCP.0014.xml' }]
+      set(doc, 'data.rfc.middle.t', [
+        boilerplateWithBCP14,
+        'Lorem ipsum SHALL lorem ipsum MUST NOT lorem RECOMMENDED.'
+      ])
+      await expect(validate2119Keywords(doc)).resolves.toHaveLength(0)
+    })
   })
 })
 


### PR DESCRIPTION
## Summary

The XML parser only extracted `<!ENTITY ... SYSTEM|PUBLIC "...">` declarations into `externalEntities`, but modern XML drafts use `<xi:include href="..."/>` elements for bibxml references (RFC, BCP, etc.). These were completely ignored, causing false `MISSING_REQLEVEL_REF` errors when RFC2119/RFC8174/BCP14 were included via `xi:include`.

## Fix

Added a second extraction pass in the XML parser that scans `xi:include` elements and extracts reference names (e.g. `RFC2119`, `BCP14`) from bibxml URLs into the same `externalEntities` array.

## Test plan

- [x] Added unit test for `xi:include`-sourced BCP14 reference in keyword validation
- [x] All 444 tests pass (`npm test`)
- [x] Ran `node cli.js` against an XML file that uses `xi:include` for RFC2119/RFC8174 references and previously triggered `MISSING_REQLEVEL_REF` — confirmed the false positive is now resolved

## Issues Resolved
- Fixes #253 