### PR TITLE
fix: an abbreviated month in the document date throws instead of reporting a nit (#276)

### DIFF
--- a/lib/modules/metadata.mjs
+++ b/lib/modules/metadata.mjs
@@ -12,9 +12,41 @@ const UPDATES_RE = /updates ((?:\[?rfcs? ?)?[0-9]+\]?(?:, | and )?)+/gi
 const RFC_NUM_RE_GENERAL = /[0-9]+/
 const RFC_NUM_RE = /[0-9]+/g
 const VERSION_SUFFIX_RE = /-([0-9]{2})$/
-const ALPHA_ONLY_RE = /^[a-zA-Z]+$/
-
 const today = DateTime.now()
+
+/**
+ * Resolve a document-date month to a number, or null when it is not one.
+ *
+ * Both callers used to hand the result of DateTime.fromFormat straight to
+ * DateTime.fromObject. An unparseable month makes that NaN, and fromObject
+ * throws on NaN, so an abbreviated or malformed month aborted the run instead
+ * of being reported. The locale is pinned because these are English-language
+ * drafts: without it the accepted spellings would follow whichever machine ran
+ * the tool.
+ *
+ * @param {string|number} value Month as it appeared in the document
+ * @returns {number|null} Month number 1-12, or null
+ */
+function parseDocMonth (value) {
+  if (typeof value === 'number') {
+    return Number.isInteger(value) && value >= 1 && value <= 12 ? value : null
+  }
+  if (typeof value !== 'string') {
+    return null
+  }
+  const trimmed = value.trim()
+  if (/^[0-9]{1,2}$/.test(trimmed)) {
+    const asNumber = Number(trimmed)
+    return asNumber >= 1 && asNumber <= 12 ? asNumber : null
+  }
+  for (const format of ['MMMM', 'MMM']) {
+    const parsed = DateTime.fromFormat(trimmed, format, { locale: 'en-US' })
+    if (parsed.isValid) {
+      return parsed.month
+    }
+  }
+  return null
+}
 
 /**
  * Validate document date
@@ -37,9 +69,16 @@ export async function validateDate (doc, { mode = MODES.NORMAL } = {}) {
           ref: 'https://authors.ietf.org/en/rfcxml-vocabulary#date'
         }))
       } else {
+        const docDateMonth = docDate.month ? parseDocMonth(docDate.month) : today.month
+        if (docDateMonth === null) {
+          result.push(new ValidationWarning('MISSING_DOC_DATE', 'The document date could not be determined.', {
+            ref: 'https://authors.ietf.org/en/rfcxml-vocabulary#date'
+          }))
+          break
+        }
         const dt = DateTime.fromObject({
           year: docDate.year || today.year,
-          month: docDate.month ? DateTime.fromFormat(docDate.month, 'MMMM').month : today.month,
+          month: docDateMonth,
           day: docDate.day || today.day
         })
         const daysDiff = Math.round(dt.diffNow().as('days'))
@@ -62,13 +101,17 @@ export async function validateDate (doc, { mode = MODES.NORMAL } = {}) {
           ref: 'https://authors.ietf.org/en/rfcxml-vocabulary#date'
         }))
       } else {
-        let docDateMonth = docDate.month
-        if (docDateMonth && ALPHA_ONLY_RE.test(docDateMonth)) {
-          docDateMonth = DateTime.fromFormat(docDate.month, 'MMMM').month
+        const docDateMonth = docDate.month ? parseDocMonth(docDate.month) : today.month
+        if (docDateMonth === null) {
+          result.push(new ValidationWarning('MISSING_DOC_DATE', 'The document date could not be determined.', {
+            ref: 'https://authors.ietf.org/en/rfcxml-vocabulary#date',
+            path: 'rfc.front.date'
+          }))
+          break
         }
         const dt = DateTime.fromObject({
           year: docDate.year || today.year,
-          month: docDateMonth || today.month,
+          month: docDateMonth,
           day: docDate.day || today.day
         })
         const daysDiff = Math.round(dt.diffNow().as('days'))

--- a/tests/metadata.test.js
+++ b/tests/metadata.test.js
@@ -316,6 +316,17 @@ describe('document should have valid date', () => {
       })
       await expect(validateDate(doc)).resolves.toHaveLength(0)
     })
+    test('non-ascii month is reported, not thrown', async () => {
+      const doc = cloneDeep(baseXMLDoc)
+      const today = DateTime.now()
+
+      set(doc, 'data.rfc.front.date._attr', {
+        year: today.year,
+        month: '8月',
+        day: today.day
+      })
+      await expect(validateDate(doc)).resolves.toContainError('MISSING_DOC_DATE', ValidationWarning)
+    })
     test('date missing', async () => {
       const doc = cloneDeep(baseXMLDoc)
       set(doc, 'data.rfc.front', {})
@@ -393,6 +404,28 @@ describe('document should have valid date', () => {
       await expect(validateDate(doc)).resolves.toContainError('DOC_DATE_IN_FUTURE', ValidationWarning)
       await expect(validateDate(doc, { mode: MODES.FORGIVE_CHECKLIST })).resolves.toContainError('DOC_DATE_IN_FUTURE', ValidationWarning)
       await expect(validateDate(doc, { mode: MODES.SUBMISSION })).resolves.toContainError('DOC_DATE_IN_FUTURE', ValidationWarning)
+    })
+    test('abbreviated month', async () => {
+      const doc = baseTXTDoc
+      const today = DateTime.now().setLocale('en-US').minus({ days: 15 })
+
+      doc.data.header.date = {
+        year: today.year,
+        month: today.monthShort,
+        day: today.day
+      }
+      await expect(validateDate(doc)).resolves.toContainError('DOC_DATE_IN_PAST', ValidationWarning)
+    })
+    test('unparseable month is reported, not thrown', async () => {
+      const doc = baseTXTDoc
+      const today = DateTime.now().setLocale('en-US')
+
+      doc.data.header.date = {
+        year: today.year,
+        month: 'Augst',
+        day: today.day
+      }
+      await expect(validateDate(doc)).resolves.toContainError('MISSING_DOC_DATE', ValidationWarning)
     })
   })
 })

--- a/tests/metadata.test.js
+++ b/tests/metadata.test.js
@@ -307,7 +307,7 @@ describe('document should have valid date', () => {
   describe('XML Document Type', () => {
     test('valid date', async () => {
       const doc = cloneDeep(baseXMLDoc)
-      const today = DateTime.now()
+      const today = DateTime.now().setLocale('en-US')
 
       set(doc, 'data.rfc.front.date._attr', {
         year: today.year,
@@ -318,7 +318,7 @@ describe('document should have valid date', () => {
     })
     test('non-ascii month is reported, not thrown', async () => {
       const doc = cloneDeep(baseXMLDoc)
-      const today = DateTime.now()
+      const today = DateTime.now().setLocale('en-US')
 
       set(doc, 'data.rfc.front.date._attr', {
         year: today.year,
@@ -336,7 +336,7 @@ describe('document should have valid date', () => {
     })
     test('date in the past', async () => {
       const doc = cloneDeep(baseXMLDoc)
-      const today = DateTime.now().minus({ days: 15 })
+      const today = DateTime.now().setLocale('en-US').minus({ days: 15 })
       set(doc, 'data.rfc.front.date._attr', {
         year: today.year,
         month: today.monthLong,
@@ -348,7 +348,7 @@ describe('document should have valid date', () => {
     })
     test('date in the future', async () => {
       const doc = cloneDeep(baseXMLDoc)
-      const today = DateTime.now().plus({ days: 15 })
+      const today = DateTime.now().setLocale('en-US').plus({ days: 15 })
       set(doc, 'data.rfc.front.date._attr', {
         year: today.year,
         month: today.monthLong,


### PR DESCRIPTION
Resolves #276.

`12 Jan 2026` in a document date header aborts the run with `InvalidArgumentError: Invalid unit value NaN`. Both date branches handed `DateTime.fromFormat(month, 'MMMM')` straight to `DateTime.fromObject`, and `MMMM` matches only full English month names, so an abbreviated month becomes `NaN` and `fromObject` throws. `DATE_RE` in the TXT parser captures the header token unmodified, so this needs no unusual input.

The XML branch had the mirror-image problem. It converted only values matching `^[a-zA-Z]+$`, so `8月` threw in the same place, while ASCII junk like `Augst` was read as the current month and produced no nit at all, because `NaN` is falsy in its `|| today.month` fallback.

Both branches now go through one `parseDocMonth`, which returns null for anything it cannot resolve so the existing `MISSING_DOC_DATE` warning is raised. It accepts full and abbreviated names and a 1-12 numeric string, with the locale pinned to `en-US`: these are English-language drafts, and which spellings are accepted should not follow whichever machine runs the tool.

Three cases added, each failing on the current code: abbreviated month resolves `DOC_DATE_IN_PAST`, `Augst` resolves `MISSING_DOC_DATE`, and `8月` in XML resolves `MISSING_DOC_DATE` rather than throwing.

The second commit is separate and unrelated to the fix: the three XML date tests build their expected month from `DateTime.now().monthLong` with no locale, so they fail on a non-English host before any change. The TXT tests beside them already pin `en-US`.

Full suite passes, `eslint` clean, no new dependencies.

One decision I have left to you rather than taking: `Sept` still resolves `MISSING_DOC_DATE`, since luxon's `MMM` expects `Sep`. Safe, but you may want it accepted.
